### PR TITLE
Added specifications to separate servers into proposers, acceptors and learners.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="bootstrap-slider/js/bootstrap-slider.js"></script>
     <script src="bootstrap-contextmenu/bootstrap-contextmenu.js"></script>
     <script src="util.js"></script>
-    <script src="raft.js"></script>
+    <script src="paxos.js"></script>
     <script src="state.js"></script>
     <script src="script.js"></script>
     <link href="style.css" rel="stylesheet">


### PR DESCRIPTION
- Changed index.html to import paxos.js instead of raft.js to test the node colorization.
- Provided methods to identify server states based on server ID, assuming ID never changes.