### PR TITLE
pbft: use clientRequestsToExecute to check pending requests

### DIFF
--- a/pbft.js
+++ b/pbft.js
@@ -1335,7 +1335,6 @@ var getMessageFieldList = function(model, message, mIndex) {
   if (message.type === MESSAGE_TYPE.CLIENT_REQUEST) {
     fields.append(li('timestamp', message.timestamp));
     fields.append(li('value', message.value));
-    fields.append(li('multicast', message.multicast));
   }
 
   if (message.type === MESSAGE_TYPE.PRE_PREPARE) {


### PR DESCRIPTION
This separates the queued requests (queuedClientRequests) that
the primary is trying to execute, form the record fo requests
that need to be executed. View change alarm now checks
clientRequestsToExecute, and the primary will queue requests
from clientRequestsToExecute into queuedClientRequests if it
has not already attempted this request in the current view.

Fixes an issue where if a primary already dequeued from
queuedClientRequests and started a pre-prepare, but failed
midway, it won't continue to time out on the unexecuted
request (it will think it was executed successfully) when
it wakes up (gets restarted).

Includes smaller fixes:
- shorten the value the client sends to just "a" - space in the log
  is limited
- make timeout increase with subsequent failed view change attempts
  (paper suggests this)