### PR TITLE
Add byzantine mode to PBFT servers

### DIFF
--- a/pbft.js
+++ b/pbft.js
@@ -1013,7 +1013,7 @@ pbft.becomeAuthentic = function(model, server) {
 
 /* Changes if server is in byzantine mode. */
 pbft.byzantineMode = function(model, server) {
-  server.isInByzantineMode != server.isInByzantineMode;
+  server.isInByzantineMode =! server.isInByzantineMode;
 }
 
 pbft.clientRequest = function(model) {

--- a/pbft.js
+++ b/pbft.js
@@ -1014,6 +1014,7 @@ pbft.becomeAuthentic = function(model, server) {
 /* Changes if server is in byzantine mode. */
 pbft.byzantineMode = function(model, server) {
   server.isInByzantineMode =! server.isInByzantineMode;
+  server.authentic = !server.isInByzantineMode
 }
 
 pbft.clientRequest = function(model) {

--- a/pbft.js
+++ b/pbft.js
@@ -1011,9 +1011,9 @@ pbft.becomeAuthentic = function(model, server) {
   pbft.reset(model, server);
 }
 
-/* "Compromises" a server and make it enter byzantine mode */
+/* Changes if server is in byzantine mode. */
 pbft.byzantineMode = function(model, server) {
-  server.isInByzantineMode = true;
+  server.isInByzantineMode != server.isInByzantineMode;
 }
 
 pbft.clientRequest = function(model) {


### PR DESCRIPTION
Adds a flag to all servers that will replace client messages passing through its process with a preset `server.byzantineSecret` string. Also added another button on server modal to turn this on/off.

Currently the replacement only happens during pre-prepare/prepare stages. I am not too confident that we don't need to touch other later phases for this to work properly. Could you please give it a look? @rfairley 